### PR TITLE
Add `with_dependency_option`

### DIFF
--- a/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
+++ b/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
@@ -32,6 +32,7 @@ pub struct AutoInsertApplyDeferredPass {
 }
 
 /// If added to a dependency edge, the edge will not be considered for auto sync point insertions.
+#[derive(Clone)]
 pub struct IgnoreDeferred;
 
 impl AutoInsertApplyDeferredPass {

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -337,10 +337,9 @@ where
         self.into_configs().after(set)
     }
 
-    /// Run before all systems in `set`.
+    /// Apply dependency option to the last added dependency.
     ///
-    /// Unlike [`before`](Self::before), this will not cause the systems in
-    /// `set` to wait for the deferred effects of `self` to be applied.
+    /// Must be called after [`before`](Self::before) or [`after`](Self::after).
     fn with_dependency_option<P: ScheduleBuildPass>(self, option: P::EdgeOptions) -> SystemConfigs {
         self.into_configs().with_dependency_option::<P>(option)
     }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -1,10 +1,7 @@
-use std::option;
-
 use bevy_utils::all_tuples;
 
 use crate::{
     schedule::{
-        auto_insert_apply_deferred::{AutoInsertApplyDeferredPass, IgnoreDeferred},
         condition::{BoxedCondition, Condition},
         graph_utils::{Ambiguity, Dependency, DependencyKind, GraphInfo},
         set::{InternedSystemSet, IntoSystemSet, SystemSet},
@@ -143,7 +140,10 @@ impl<T> NodeConfigs<T> {
         }
     }
 
-    fn with_dependency_option_inner<P: ScheduleBuildPass>(&mut self, option: P::EdgeOptions) -> Option<&Dependency> {
+    fn with_dependency_option_inner<P: ScheduleBuildPass>(
+        &mut self,
+        option: P::EdgeOptions,
+    ) -> Option<&Dependency> {
         match self {
             Self::NodeConfig(config) => {
                 let last_pass =

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -1,3 +1,5 @@
+use std::option;
+
 use bevy_utils::all_tuples;
 
 use crate::{
@@ -227,21 +229,17 @@ impl<T> NodeConfigs<T> {
         self
     }
 
-    fn chain_ignore_deferred_inner(mut self) -> Self {
-        match &mut self {
+    fn with_chain_option_inner<P: ScheduleBuildPass>(&mut self, option: P::EdgeOptions) {
+        match self {
             Self::NodeConfig(_) => { /* no op */ }
             Self::Configs { chained, .. } => {
-                if matches!(chained, Chain::Unchained) {
-                    *chained = Chain::Chained(Default::default());
-                };
                 if let Chain::Chained(config) = chained {
-                    config.add_edge_config::<AutoInsertApplyDeferredPass>(IgnoreDeferred);
+                    config.add_edge_config::<P>(option);
                 } else {
-                    unreachable!()
+                    panic!("`with_chain_option` must be called after `chain`");
                 };
             }
         }
-        self
     }
 }
 
@@ -410,7 +408,7 @@ where
     ///
     /// If the preceeding node on a edge has deferred parameters, a [`apply_deferred`](crate::schedule::apply_deferred)
     /// will be inserted on the edge. If this behavior is not desired consider using
-    /// [`chain_ignore_deferred`](Self::chain_ignore_deferred) instead.
+    /// [`with_chain_options`](Self::with_chain_options) to disable this behavior.
     fn chain(self) -> SystemConfigs {
         self.into_configs().chain()
     }
@@ -420,8 +418,8 @@ where
     /// Ordering constraints will be applied between the successive elements.
     ///
     /// Unlike [`chain`](Self::chain) this will **not** add [`apply_deferred`](crate::schedule::apply_deferred) on the edges.
-    fn chain_ignore_deferred(self) -> SystemConfigs {
-        self.into_configs().chain_ignore_deferred()
+    fn with_chain_option<P: ScheduleBuildPass>(mut self, option: P::EdgeOptions) -> SystemConfigs {
+        self.into_configs().with_chain_option::<P>(option)
     }
 }
 
@@ -487,8 +485,9 @@ impl IntoSystemConfigs<()> for SystemConfigs {
         self.chain_inner()
     }
 
-    fn chain_ignore_deferred(self) -> Self {
-        self.chain_ignore_deferred_inner()
+    fn with_chain_option<P: ScheduleBuildPass>(mut self, option: P::EdgeOptions) -> SystemConfigs {
+        self.with_chain_option_inner::<P>(option);
+        self
     }
 }
 
@@ -573,10 +572,9 @@ where
         self.into_configs().after(set)
     }
 
-    /// Run before all systems in `set`.
+    /// Apply dependency option to the last added dependency.
     ///
-    /// Unlike [`before`](Self::before), this will not cause the systems in `set` to wait for the
-    /// deferred effects of `self` to be applied.
+    /// Must be called after [`before`](Self::before) or [`after`](Self::after).
     fn with_dependency_option<P: ScheduleBuildPass>(
         self,
         option: P::EdgeOptions,
@@ -611,13 +609,10 @@ where
         self.into_configs().chain()
     }
 
-    /// Treat this collection as a sequence of systems.
-    ///
-    /// Ordering constraints will be applied between the successive elements.
-    ///
-    /// Unlike [`chain`](Self::chain) this will **not** add [`apply_deferred`](crate::schedule::apply_deferred) on the edges.
-    fn chain_ignore_deferred(self) -> SystemConfigs {
-        self.into_configs().chain_ignore_deferred()
+    /// Apply dependency option to all dependencies between this sequence of system sets.
+    /// Must be called after [`chain`](Self::chain).
+    fn with_chain_option<P: ScheduleBuildPass>(self, option: P::EdgeOptions) -> SystemSetConfigs {
+        self.into_configs().with_chain_option::<P>(option)
     }
 }
 
@@ -680,6 +675,11 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
 
     fn chain(self) -> Self {
         self.chain_inner()
+    }
+
+    fn with_chain_option<P: ScheduleBuildPass>(mut self, option: P::EdgeOptions) -> Self {
+        self.with_chain_option_inner::<P>(option);
+        self
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -143,7 +143,7 @@ impl<T> NodeConfigs<T> {
         }
     }
 
-    fn with_dependency_option_inner<P: ScheduleBuildPass>(&mut self, option: P::EdgeOptions) {
+    fn with_dependency_option_inner<P: ScheduleBuildPass>(&mut self, option: P::EdgeOptions) -> Option<&Dependency> {
         match self {
             Self::NodeConfig(config) => {
                 let last_pass =
@@ -151,11 +151,34 @@ impl<T> NodeConfigs<T> {
                         "`before` or `after` must be called prior to `with_dependency_option`",
                     );
                 last_pass.add_config::<P>(option);
+                Some(last_pass)
             }
             Self::Configs { configs, .. } => {
+                let mut dependency: Option<&Dependency> = None;
+                // While iterating through the config list, we check to ensure that the
+                // last dependency added to each config is the same.
+                // This is to reject situations like this:
+                // ```
+                // schedule.add_systems((
+                //     system_a.before(xxx),
+                //     system_b.after(yyyy)
+                // ).with_dependency_option::<P>(zzz));
+                // ```
+
                 for config in configs {
-                    config.with_dependency_option_inner::<P>(option.clone());
+                    let dependency2 = config.with_dependency_option_inner::<P>(option.clone());
+                    if let Some(dependency2) = dependency2 {
+                        if let Some(dependency) = dependency {
+                            assert!(
+                                dependency.set == dependency2.set && dependency.kind == dependency2.kind,
+                                "`before` or `after` must be called prior to `with_dependency_option`"
+                            );
+                        } else {
+                            dependency = Some(dependency2);
+                        }
+                    }
                 }
+                dependency
             }
         }
     }
@@ -418,7 +441,7 @@ where
     /// Ordering constraints will be applied between the successive elements.
     ///
     /// Unlike [`chain`](Self::chain) this will **not** add [`apply_deferred`](crate::schedule::apply_deferred) on the edges.
-    fn with_chain_option<P: ScheduleBuildPass>(mut self, option: P::EdgeOptions) -> SystemConfigs {
+    fn with_chain_option<P: ScheduleBuildPass>(self, option: P::EdgeOptions) -> SystemConfigs {
         self.into_configs().with_chain_option::<P>(option)
     }
 }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -11,6 +11,8 @@ use crate::{
     system::{BoxedSystem, IntoSystem, System},
 };
 
+use super::ScheduleBuildPass;
+
 fn new_condition<M>(condition: impl Condition<M>) -> BoxedCondition {
     let condition_system = IntoSystem::into_system(condition);
     assert!(
@@ -139,33 +141,17 @@ impl<T> NodeConfigs<T> {
         }
     }
 
-    fn before_ignore_deferred_inner(&mut self, set: InternedSystemSet) {
+    fn with_dependency_option_inner<P: ScheduleBuildPass>(&mut self, option: P::EdgeOptions) {
         match self {
             Self::NodeConfig(config) => {
-                config.graph_info.dependencies.push(
-                    Dependency::new(DependencyKind::Before, set)
-                        .add_config::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
+                let last_pass = config.graph_info.dependencies.last_mut().expect(
+                    "`before` or `after` must be called prior to `with_dependency_option`"
                 );
+                last_pass.add_config::<P>(option);
             }
             Self::Configs { configs, .. } => {
                 for config in configs {
-                    config.before_ignore_deferred_inner(set.intern());
-                }
-            }
-        }
-    }
-
-    fn after_ignore_deferred_inner(&mut self, set: InternedSystemSet) {
-        match self {
-            Self::NodeConfig(config) => {
-                config.graph_info.dependencies.push(
-                    Dependency::new(DependencyKind::After, set)
-                        .add_config::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
-                );
-            }
-            Self::Configs { configs, .. } => {
-                for config in configs {
-                    config.after_ignore_deferred_inner(set.intern());
+                    config.with_dependency_option_inner::<P>(option.clone());
                 }
             }
         }
@@ -333,16 +319,8 @@ where
     ///
     /// Unlike [`before`](Self::before), this will not cause the systems in
     /// `set` to wait for the deferred effects of `self` to be applied.
-    fn before_ignore_deferred<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
-        self.into_configs().before_ignore_deferred(set)
-    }
-
-    /// Run after all systems in `set`.
-    ///
-    /// Unlike [`after`](Self::after), this will not wait for the deferred
-    /// effects of systems in `set` to be applied.
-    fn after_ignore_deferred<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
-        self.into_configs().after_ignore_deferred(set)
+    fn with_dependency_option<P: ScheduleBuildPass>(self, option: P::EdgeOptions) -> SystemConfigs {
+        self.into_configs().with_dependency_option::<P>(option)
     }
 
     /// Add a run condition to each contained system.
@@ -475,15 +453,8 @@ impl IntoSystemConfigs<()> for SystemConfigs {
         self
     }
 
-    fn before_ignore_deferred<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = set.into_system_set();
-        self.before_ignore_deferred_inner(set.intern());
-        self
-    }
-
-    fn after_ignore_deferred<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = set.into_system_set();
-        self.after_ignore_deferred_inner(set.intern());
+    fn with_dependency_option<P: ScheduleBuildPass>(mut self, option: P::EdgeOptions) -> SystemConfigs {
+        self.with_dependency_option_inner::<P>(option);
         self
     }
 
@@ -602,16 +573,8 @@ where
     ///
     /// Unlike [`before`](Self::before), this will not cause the systems in `set` to wait for the
     /// deferred effects of `self` to be applied.
-    fn before_ignore_deferred<M>(self, set: impl IntoSystemSet<M>) -> SystemSetConfigs {
-        self.into_configs().before_ignore_deferred(set)
-    }
-
-    /// Run after all systems in `set`.
-    ///
-    /// Unlike [`after`](Self::after), this may not see the deferred
-    /// effects of systems in `set` to be applied.
-    fn after_ignore_deferred<M>(self, set: impl IntoSystemSet<M>) -> SystemSetConfigs {
-        self.into_configs().after_ignore_deferred(set)
+    fn with_dependency_option<P: ScheduleBuildPass>(self, option: P::EdgeOptions) -> SystemSetConfigs {
+        self.into_configs().with_dependency_option::<P>(option)
     }
 
     /// Run the systems in this set(s) only if the [`Condition`] is `true`.
@@ -681,17 +644,8 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
         self
     }
 
-    fn before_ignore_deferred<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = set.into_system_set();
-        self.before_ignore_deferred_inner(set.intern());
-
-        self
-    }
-
-    fn after_ignore_deferred<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = set.into_system_set();
-        self.after_ignore_deferred_inner(set.intern());
-
+    fn with_dependency_option<P: ScheduleBuildPass>(mut self, option: P::EdgeOptions) -> SystemSetConfigs {
+        self.with_dependency_option_inner::<P>(option);
         self
     }
 

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -144,9 +144,10 @@ impl<T> NodeConfigs<T> {
     fn with_dependency_option_inner<P: ScheduleBuildPass>(&mut self, option: P::EdgeOptions) {
         match self {
             Self::NodeConfig(config) => {
-                let last_pass = config.graph_info.dependencies.last_mut().expect(
-                    "`before` or `after` must be called prior to `with_dependency_option`"
-                );
+                let last_pass =
+                    config.graph_info.dependencies.last_mut().expect(
+                        "`before` or `after` must be called prior to `with_dependency_option`",
+                    );
                 last_pass.add_config::<P>(option);
             }
             Self::Configs { configs, .. } => {
@@ -453,7 +454,10 @@ impl IntoSystemConfigs<()> for SystemConfigs {
         self
     }
 
-    fn with_dependency_option<P: ScheduleBuildPass>(mut self, option: P::EdgeOptions) -> SystemConfigs {
+    fn with_dependency_option<P: ScheduleBuildPass>(
+        mut self,
+        option: P::EdgeOptions,
+    ) -> SystemConfigs {
         self.with_dependency_option_inner::<P>(option);
         self
     }
@@ -573,7 +577,10 @@ where
     ///
     /// Unlike [`before`](Self::before), this will not cause the systems in `set` to wait for the
     /// deferred effects of `self` to be applied.
-    fn with_dependency_option<P: ScheduleBuildPass>(self, option: P::EdgeOptions) -> SystemSetConfigs {
+    fn with_dependency_option<P: ScheduleBuildPass>(
+        self,
+        option: P::EdgeOptions,
+    ) -> SystemSetConfigs {
         self.into_configs().with_dependency_option::<P>(option)
     }
 
@@ -644,7 +651,10 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
         self
     }
 
-    fn with_dependency_option<P: ScheduleBuildPass>(mut self, option: P::EdgeOptions) -> SystemSetConfigs {
+    fn with_dependency_option<P: ScheduleBuildPass>(
+        mut self,
+        option: P::EdgeOptions,
+    ) -> SystemSetConfigs {
         self.with_dependency_option_inner::<P>(option);
         self
     }

--- a/crates/bevy_ecs/src/schedule/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule/graph_utils.rs
@@ -64,9 +64,8 @@ impl Dependency {
             options: Default::default(),
         }
     }
-    pub fn add_config<T: ScheduleBuildPass>(mut self, option: T::EdgeOptions) -> Self {
+    pub fn add_config<T: ScheduleBuildPass>(&mut self, option: T::EdgeOptions) {
         self.options.add_edge_config::<T>(option);
-        self
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -2251,7 +2251,8 @@ mod tests {
                             },
                         ),
                     )
-                        .chain_ignore_deferred(),
+                        .chain()
+                        .with_chain_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
                 );
             });
         }
@@ -2306,7 +2307,8 @@ mod tests {
                             },
                         ),
                     )
-                        .chain_ignore_deferred(),
+                        .chain()
+                        .with_chain_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
                 );
             });
         }
@@ -2367,7 +2369,8 @@ mod tests {
                         )
                             .chain(),
                     )
-                        .chain_ignore_deferred(),
+                        .chain()
+                        .with_chain_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
                 );
             });
         }
@@ -2436,7 +2439,8 @@ mod tests {
                         )
                             .chain(),
                     )
-                        .chain_ignore_deferred(),
+                        .chain()
+                        .with_chain_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
                 );
             });
         }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1947,8 +1947,8 @@ mod tests {
         self as bevy_ecs,
         prelude::{Res, Resource},
         schedule::{
-            IntoSystemConfigs, IntoSystemSetConfigs, Schedule, ScheduleBuildSettings, SystemSet,
             auto_insert_apply_deferred::{AutoInsertApplyDeferredPass, IgnoreDeferred},
+            IntoSystemConfigs, IntoSystemSetConfigs, Schedule, ScheduleBuildSettings, SystemSet,
         },
         system::Commands,
         world::World,
@@ -2099,7 +2099,9 @@ mod tests {
             check_no_sync_edges(|schedule| {
                 schedule.add_systems((
                     insert_resource,
-                    resource_does_not_exist.after(insert_resource).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
+                    resource_does_not_exist
+                        .after(insert_resource)
+                        .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
                 ));
             });
         }
@@ -2108,7 +2110,9 @@ mod tests {
         fn system_to_system_before() {
             check_no_sync_edges(|schedule| {
                 schedule.add_systems((
-                    insert_resource.before(resource_does_not_exist).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
+                    insert_resource
+                        .before(resource_does_not_exist)
+                        .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
                     resource_does_not_exist,
                 ));
             });
@@ -2119,7 +2123,11 @@ mod tests {
             check_no_sync_edges(|schedule| {
                 schedule
                     .add_systems((insert_resource, resource_does_not_exist.in_set(Sets::A)))
-                    .configure_sets(Sets::A.after(insert_resource).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
+                    .configure_sets(
+                        Sets::A
+                            .after(insert_resource)
+                            .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
+                    );
             });
         }
 
@@ -2128,7 +2136,11 @@ mod tests {
             check_no_sync_edges(|schedule| {
                 schedule
                     .add_systems((insert_resource.in_set(Sets::A), resource_does_not_exist))
-                    .configure_sets(Sets::A.before(resource_does_not_exist).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
+                    .configure_sets(
+                        Sets::A
+                            .before(resource_does_not_exist)
+                            .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
+                    );
             });
         }
 
@@ -2140,7 +2152,11 @@ mod tests {
                         insert_resource.in_set(Sets::A),
                         resource_does_not_exist.in_set(Sets::B),
                     ))
-                    .configure_sets(Sets::B.after(Sets::A).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
+                    .configure_sets(
+                        Sets::B
+                            .after(Sets::A)
+                            .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
+                    );
             });
         }
 
@@ -2152,18 +2168,22 @@ mod tests {
                         insert_resource.in_set(Sets::A),
                         resource_does_not_exist.in_set(Sets::B),
                     ))
-                    .configure_sets(Sets::A.before(Sets::B).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
+                    .configure_sets(
+                        Sets::A
+                            .before(Sets::B)
+                            .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
+                    );
             });
         }
 
         #[test]
-        #[should_panic(expected = "`before` or `after` must be called prior to `with_dependency_option`")]
+        #[should_panic(
+            expected = "`before` or `after` must be called prior to `with_dependency_option`"
+        )]
         fn panic_on_dangling_dependency_option() {
             let mut schedule = Schedule::default();
-            schedule
-            .add_systems((
-                insert_resource.with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
-            ));
+            schedule.add_systems((insert_resource
+                .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),));
         }
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -2180,9 +2180,12 @@ mod tests {
         #[should_panic(
             expected = "`before` or `after` must be called prior to `with_dependency_option`"
         )]
-        fn panic_on_dangling_dependency_option() {            let mut schedule = Schedule::default();
-            schedule.add_systems(insert_resource
-                .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
+        fn panic_on_dangling_dependency_option() {
+            let mut schedule = Schedule::default();
+            schedule.add_systems(
+                insert_resource
+                    .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
+            );
         }
 
         #[test]
@@ -2191,10 +2194,13 @@ mod tests {
         )]
         fn panic_on_dangling_group_dependency_option() {
             let mut schedule = Schedule::default();
-            schedule.add_systems((
-                insert_resource.before(resource_does_not_exist),
-                resource_does_not_exist.after(insert_resource),
-            ).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
+            schedule.add_systems(
+                (
+                    insert_resource.before(resource_does_not_exist),
+                    resource_does_not_exist.after(insert_resource),
+                )
+                    .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
+            );
         }
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -2180,10 +2180,21 @@ mod tests {
         #[should_panic(
             expected = "`before` or `after` must be called prior to `with_dependency_option`"
         )]
-        fn panic_on_dangling_dependency_option() {
+        fn panic_on_dangling_dependency_option() {            let mut schedule = Schedule::default();
+            schedule.add_systems(insert_resource
+                .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "`before` or `after` must be called prior to `with_dependency_option`"
+        )]
+        fn panic_on_dangling_group_dependency_option() {
             let mut schedule = Schedule::default();
-            schedule.add_systems((insert_resource
-                .with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),));
+            schedule.add_systems((
+                insert_resource.before(resource_does_not_exist),
+                resource_does_not_exist.after(insert_resource),
+            ).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
         }
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1818,7 +1818,7 @@ pub enum LogLevel {
 /// A pass for modular modification of the dependency graph.
 pub trait ScheduleBuildPass: Send + Sync + Debug + 'static {
     /// Custom options for dependencies between sets or systems.
-    type EdgeOptions: 'static;
+    type EdgeOptions: Clone + 'static;
 
     /// Called when a dependency between sets or systems was explicitly added to the graph.
     fn add_dependency(&mut self, from: NodeId, to: NodeId, options: Option<&Self::EdgeOptions>);
@@ -1948,6 +1948,7 @@ mod tests {
         prelude::{Res, Resource},
         schedule::{
             IntoSystemConfigs, IntoSystemSetConfigs, Schedule, ScheduleBuildSettings, SystemSet,
+            auto_insert_apply_deferred::{AutoInsertApplyDeferredPass, IgnoreDeferred},
         },
         system::Commands,
         world::World,
@@ -2098,7 +2099,7 @@ mod tests {
             check_no_sync_edges(|schedule| {
                 schedule.add_systems((
                     insert_resource,
-                    resource_does_not_exist.after_ignore_deferred(insert_resource),
+                    resource_does_not_exist.after(insert_resource).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
                 ));
             });
         }
@@ -2107,7 +2108,7 @@ mod tests {
         fn system_to_system_before() {
             check_no_sync_edges(|schedule| {
                 schedule.add_systems((
-                    insert_resource.before_ignore_deferred(resource_does_not_exist),
+                    insert_resource.before(resource_does_not_exist).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
                     resource_does_not_exist,
                 ));
             });
@@ -2118,7 +2119,7 @@ mod tests {
             check_no_sync_edges(|schedule| {
                 schedule
                     .add_systems((insert_resource, resource_does_not_exist.in_set(Sets::A)))
-                    .configure_sets(Sets::A.after_ignore_deferred(insert_resource));
+                    .configure_sets(Sets::A.after(insert_resource).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
             });
         }
 
@@ -2127,7 +2128,7 @@ mod tests {
             check_no_sync_edges(|schedule| {
                 schedule
                     .add_systems((insert_resource.in_set(Sets::A), resource_does_not_exist))
-                    .configure_sets(Sets::A.before_ignore_deferred(resource_does_not_exist));
+                    .configure_sets(Sets::A.before(resource_does_not_exist).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
             });
         }
 
@@ -2139,7 +2140,7 @@ mod tests {
                         insert_resource.in_set(Sets::A),
                         resource_does_not_exist.in_set(Sets::B),
                     ))
-                    .configure_sets(Sets::B.after_ignore_deferred(Sets::A));
+                    .configure_sets(Sets::B.after(Sets::A).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
             });
         }
 
@@ -2151,8 +2152,18 @@ mod tests {
                         insert_resource.in_set(Sets::A),
                         resource_does_not_exist.in_set(Sets::B),
                     ))
-                    .configure_sets(Sets::A.before_ignore_deferred(Sets::B));
+                    .configure_sets(Sets::A.before(Sets::B).with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred));
             });
+        }
+
+        #[test]
+        #[should_panic(expected = "`before` or `after` must be called prior to `with_dependency_option`")]
+        fn panic_on_dangling_dependency_option() {
+            let mut schedule = Schedule::default();
+            schedule
+            .add_systems((
+                insert_resource.with_dependency_option::<AutoInsertApplyDeferredPass>(IgnoreDeferred),
+            ));
         }
     }
 


### PR DESCRIPTION
# Objective

Have more configurable ways to define dependency properties

## Solution

Instead of calling `before_ignore_deferred` and `after_ignore_deferred`, call `.before().with_dependency_options::<NameOfTransformPass>(DependencyOption)`.
